### PR TITLE
Remove important overrides

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -121,12 +121,12 @@ section {
 }
 
 /* !important overrides .data h3 */
-.reroute {
-  color: #F2994A !important;
+.data .reroute {
+  color: #F2994A;
 }
 
-.resumes {
-  color: #EB1C24 !important;
+.data .resumes {
+  color: #EB1C24;
 }
 
 .destination {


### PR DESCRIPTION
Alissa Likavec suggested that I remove the !important ovverride because they quickly get out of hand. I replaced it with .data .reroute in the css.